### PR TITLE
allow NaN/Inf values in JSON

### DIFF
--- a/src/PlotlyLight.jl
+++ b/src/PlotlyLight.jl
@@ -76,7 +76,7 @@ function download_schema!()
 end
 function load_schema(force=false)
     if force || !isassigned(schema)
-        schema[] = JSON3.read(open(joinpath(scratch_dir[], "plotly-schema.json"), "r"), Config)
+        schema[] = JSON3.read(open(joinpath(scratch_dir[], "plotly-schema.json"), "r"), Config; allow_inf=true)
     end
     return schema[]
 end
@@ -160,7 +160,7 @@ module Preset
                 export $f
                 function $f()
                     file = joinpath(templates_dir[], $(string(t)) * ".json")
-                    SETTINGS.layout.template = open(io -> JSON3.read(io, Config), file)
+                    SETTINGS.layout.template = open(io -> JSON3.read(io, Config; allow_inf=true), file)
                     return SETTINGS
                 end
             end
@@ -267,7 +267,7 @@ function Base.show(io::IO, M::MIME"text/html", o::Plot; setting::Settings = SETT
         show(io, M, setting.load_plotlyjs())
         show(io, M, setting.make_container(id))
         print(io, "<script>Plotly.newPlot(", repr(id), ", ")
-        foreach(x -> (JSON3.write(io, x); print(io, ", ")), (data, layout, config))
+        foreach(x -> (JSON3.write(io, x; allow_inf=true); print(io, ", ")), (data, layout, config))
         print(io, ")</script>")
     else
         iframe = setting.iframe


### PR DESCRIPTION
Resolves #35
Enabled NaN/Inf support in JSON3 read/write calls, Plotly schema seems to allow it.
